### PR TITLE
Rework nixos support

### DIFF
--- a/other_distros/NixOS/INSTALL.md
+++ b/other_distros/NixOS/INSTALL.md
@@ -1,4 +1,4 @@
-There are 3 ways to install fastermelee on nixos:
+There are 3 ways to install fastermelee on nixos. To install version 5.8.7, replace every instance of 5.9 with 5.8.7 and 5-9 with 5-8-7.
 
 1. To install locally, just run `nix-shell` in this directory then execute the setup script
 

--- a/other_distros/NixOS/INSTALL.md
+++ b/other_distros/NixOS/INSTALL.md
@@ -1,6 +1,24 @@
-# nixOS Installation Guide
+There are 3 ways to install fastermelee on nixos:
 
-### 1. run nix-shell on [shell.nix](./shell.nix)
+1. To install locally, just run `nix-shell` in this directory then execute the setup script
 
-### 2. run the setup script
+2. To install globally, run `nix-env -f ./default.nix -iA fastermelee-5-9` or add `(callPackage /path/to/fastermelee-5.9 {})` to `environment.systemPackages`. You can launch dolphin with the command `fastermelee` or `fastermelee-nogui`.
 
+3. If you just want to try it out you can run `nix-build` in this directory. The executables will be in `./result/bin`.
+
+No matter how you install, be sure to add the following lines to your configuration.nix in order to get gamecube adapters to work:
+
+```
+services.udev.extraRules = ''
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0666";
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2300", SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1", ENV{ID_MM_CANDIDATE}:="0";
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2301", SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1", ENV{ID_MM_CANDIDATE}:="0";
+'';
+```
+
+If installed using methods 2 or 3, the `Sys` directory is copied to the nix store and will be read-only. The `User` directory will be in `$XDG_CONFIG_HOME/fastermelee` with write permission. To use a custom `Sys` or `User` directory, you can install by running:<br/>
+`nix-env -f ./default.nix -iA fastermelee-5-9 --arg sys /path/to/sys --arg user /path/to/user`<br/>
+or adding<br/>
+`(callPackage /path/to/fastermelee-5.9 { sys = /path/to/Sys; user = /path/to/User; })` to `environment.systemPackages`<br/>
+or running<br/>
+`nix-build -E 'with import <nixpkgs> { }; callPackage ./fastermelee-5.9 { sys = /path/to/Sys; user = /path/to/User; }'`<br/>

--- a/other_distros/NixOS/default.nix
+++ b/other_distros/NixOS/default.nix
@@ -3,5 +3,6 @@
 with pkgs;
 {
   fastermelee-5-9 = callPackage ./fastermelee-5.9 { inherit sys user; };
+  fastermelee-5-8-7 = callPackage ./fastermelee-5.8.7 { inherit sys user; };
 
 }

--- a/other_distros/NixOS/default.nix
+++ b/other_distros/NixOS/default.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {}, sys ? null, user ? null, }:
+
+with pkgs;
+{
+  fastermelee-5-9 = callPackage ./fastermelee-5.9 { inherit sys user; };
+
+}

--- a/other_distros/NixOS/fastermelee-5.8.7/default.nix
+++ b/other_distros/NixOS/fastermelee-5.8.7/default.nix
@@ -1,0 +1,106 @@
+{ stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib, libGLU_combined
+, gettext, libpthreadstubs, libXrandr, libXext, libX11, libSM, readline, openal
+, libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev, automake, autobuild
+, wxGTK31, soundtouch, miniupnpc, mbedtls, curl, lzo, sfml, gnumake
+, writeShellScriptBin, symlinkJoin, libpulseaudio ? null, sys ? null, user ? null }:
+
+# the optional sys and user parameters are paths to the respective directories for dolphin
+# if not given dolphin will just use the default fastermelee sys and user dirs
+# passing custom sys and user directories may be useful for installing project m
+
+let
+  # there are 2 wrapper scripts that will copy the necessary config files to $HOME/.config
+  # fastermelee is always called with the -u option so it reads the correct user dir
+  fastermelee = writeShellScriptBin "fastermelee-5.8.7" ''
+    config=$HOME/.config
+    if [ ! -z "$XDG_CONFIG_HOME" ]; then
+        config="$XDG_CONFIG_HOME"
+    fi
+    if [ ! -d $config/fastermelee-5.8.7 ] ; then
+        mkdir -p $config
+        cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee-5.8.7
+        chmod -R +w $config/fastermelee-5.8.7
+    fi
+    ${fastermelee-dolphin}/bin/fastermelee-5.8.7 -u $config/fastermelee-5.8.7 $@
+  '';
+
+
+  fastermelee-nogui = writeShellScriptBin "fastermelee-5.8.7-nogui" ''
+    config=$HOME/.config
+    if [ ! -z "$XDG_CONFIG_HOME" ]; then
+        config="$XDG_CONFIG_HOME"
+    fi
+    if [ ! -d $config/fastermelee-5.8.7 ] ; then
+        mkdir -p $config
+        cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee-5.8.7
+        chmod -R +w $config/fastermelee-5.8.7
+    fi
+    ${fastermelee-dolphin}/bin/fastermelee-5.8.7-nogui $@
+  '';
+
+  fasterMeleeConfig = builtins.fetchTarball {
+    url = https://github.com/FasterMelee/FasterMelee-installer/raw/master/config/legacy/5.8.7-fmconfig.tar.gz;
+    sha256 = "1a3yk289jzfhapymksr4nj4np6hxm78h20mrjd6mqs2q0y9vvmv3";
+  };
+
+  sysDir = if sys== null then
+             "${fasterMeleeConfig}/Sys"
+           else
+             sys;
+
+
+  userDir = if user == null then
+             "${fasterMeleeConfig}/User"
+           else
+             user;
+
+
+  fastermelee-dolphin = stdenv.mkDerivation rec {
+    name = "FasterMelee-base";
+    version = "5.8.7";
+
+    src = fetchFromGitHub {
+      owner  = "FasterMelee";
+      repo   = "Ishiiruka";
+      rev = "98ebbc166beee649bd23066ce91ba1d88e73861c";
+      sha256 = "15wwkv5cn9dxdmqmzmpncq7myg6q5v53ql5hrplpglpp3gkhs9di";
+    };
+
+    postPatch = builtins.readFile ./postpatch;
+
+    cmakeFlags = ''
+      -DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include
+      -DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include
+      -DGTK2_INCLUDE_DIRS=${gtk2.dev}/lib/gtk-2.0
+      -DENABLE_LTO=True
+
+    '';
+
+    postInstall = ''
+      rm -r "$out/share/dolphin-emu/sys"
+      cp -r "${userDir}" "$out/share/dolphin-emu/user/"
+      cp -r "${sysDir}" "$out/share/dolphin-emu/sys/"
+      mv "$out/bin/dolphin-emu" "$out/bin/fastermelee-5.8.7"
+      mv "$out/bin/dolphin-emu-nogui" "$out/bin/fastermelee-5.8.7-nogui"
+    '';
+
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ pkgconfig cmake ];
+
+    buildInputs = [ bluez ffmpeg libao libGLU_combined gtk2 glib
+    gettext libpthreadstubs libXrandr libXext libX11 libSM readline
+    openal libevdev libXdmcp portaudio libusb libpulseaudio gnumake
+    wxGTK31 soundtouch miniupnpc mbedtls curl lzo sfml ];
+
+  };
+
+in
+  symlinkJoin {
+  name = "fastermelee-5.8.7";
+  paths = [
+    fastermelee
+    fastermelee-nogui
+    fastermelee-dolphin
+  ];
+}

--- a/other_distros/NixOS/fastermelee-5.8.7/postpatch
+++ b/other_distros/NixOS/fastermelee-5.8.7/postpatch
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# --- Dirty patch for https://bugs.dolphin-emu.org/issues/11047
+echo "Patching xgetbv function..."
+sed -i "s|#include <cstring>|#include <cstring>\n#define _XSAVEINTRIN_H_INCLUDED|g" Source/Core/Common/x64CPUDetect.cpp
+
+# --- Patch for https://github.com/FasterMelee/Ishiiruka/pull/4/commits/8d161226ab915be09c951957505da61c217b1b1b
+echo "Patching FileUtil.cpp..."
+sed -i "s|#include <fcntl.h>|#include <fcntl.h>\n#include <fstream>|g" Source/Core/Common/FileUtil.cpp # add in include
+sed -i '/\/\/ copies file srcFilename to destFilename, returns true on success/d' Source/Core/Common/FileUtil.cpp # update variable names
+sed -i "s|bool Copy(const std::string& srcFilename, const std::string& destFilename)|\/\/ copies file source_path to destination_path, returns true on success\nbool Copy(const std::string\& source_path, const std::string\& destination_path)|g" Source/Core/Common/FileUtil.cpp # update variable names
+sed -i 's|INFO_LOG(COMMON, "Copy: %s --> %s", srcFilename.c_str(), destFilename.c_str());|INFO_LOG(COMMON, "Copy: %s --> %s", source_path.c_str(), destination_path.c_str());|g' Source/Core/Common/FileUtil.cpp # update variable names
+sed -i "s|if (CopyFile(UTF8ToTStr(srcFilename).c_str(), UTF8ToTStr(destFilename).c_str(), FALSE))|if (CopyFile(UTF8ToTStr(source_path).c_str(), UTF8ToTStr(destination_path).c_str(), FALSE))|g" Source/Core/Common/FileUtil.cpp # update variable names
+sed -i 's|ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s", srcFilename.c_str(), destFilename.c_str(),|ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s", source_path.c_str(), destination_path.c_str(),|g' Source/Core/Common/FileUtil.cpp # update variable names
+sed -i "315,361d" Source/Core/Common/FileUtil.cpp # remove old copy method
+sed -i "314istd::ifstream source{source_path, std::ios::binary};\nstd::ofstream destination{destination_path, std::ios::binary};\ndestination << source.rdbuf();\nreturn source.good() && destination.good();" Source/Core/Common/FileUtil.cpp # add new copy method
+# ---
+
+# --- Patch WxUtils regarding https://github.com/FasterMelee/FasterMelee-installer/issues/58
+echo "Patching WxUtils.cpp..."
+sed -i "s|screen_geometry = wxDisplay(0).GetClientArea();|screen_geometry = wxDisplay((unsigned int) 0).GetClientArea();|g" Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
+sed -i 's|default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);|default_size.SetDefaults(wxDisplay((unsigned int) 0).GetClientArea().GetSize() / 2);|g' Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
+# ---
+
+# --- Temporary patch for updated glibc		
+echo "Patching xlocale.h requirement..."		
+sed -i "s|#define wxUSE_XLOCALE 1|#define wxUSE_XLOCALE 0|g" Externals/wxWidgets3/wx/wxcocoa.h		
+sed -i "s|#define wxUSE_XLOCALE 1|#define wxUSE_XLOCALE 0|g" Externals/wxWidgets3/wx/wxgtk.h		
+# ---
+
+# --- Patch for https://github.com/dolphin-emu/dolphin/pull/6603/files		
+echo "Patching AVIDump.cpp..."		
+sed -i "s|CODEC_FLAG_GLOBAL_HEADER|AV_CODEC_FLAG_GLOBAL_HEADER|g" Source/Core/VideoCommon/AVIDump.cpp # replace existing objects first		
+sed -i "s|#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 28, 1)|#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 28, 1)\n#define AV_CODEC_FLAG_GLOBAL_HEADER CODEC_FLAG_GLOBAL_HEADER|g" Source/Core/VideoCommon/AVIDump.cpp # add in define		
+# ---
+
+# --- Patch tarball to display correct hash to other netplay clients
+echo "Patching tarball..."
+sed -i "s|\${GIT_EXECUTABLE} rev-parse HEAD|echo 6ababb9222fb8bb9723ae137e1263a27196fcd47|g" CMakeLists.txt  # --set scm_rev_str everywhere to actual commit hash when downloaded
+sed -i "s|\${GIT_EXECUTABLE} describe --always --long --dirty|echo FM v$FMVERSION BETA|g" CMakeLists.txt # ensures compatibility w/ netplay
+sed -i "s|\${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD|echo HEAD|g" CMakeLists.txt
+# ---
+
+# --- Patch for SoundTouch
+echo "Using static soundtouch from Externals..."
+sed -i 's|message("Using shared soundtouch")|add_subdirectory(Externals/soundtouch)\n\tinclude_directories(Externals)|g' CMakeLists.txt #uses external soundtouch lib
+# ---
+
+echo "patching cubeb"
+sed -i "s|install(DIRECTORY \${CMAKE_SOURCE_DIR}/include DESTINATION \${CMAKE_INSTALL_PREFIX})|install(DIRECTORY \${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION \${CMAKE_INSTALL_PREFIX})|g" Externals/cubeb/CMakeLists.txt

--- a/other_distros/NixOS/fastermelee-5.9/default.nix
+++ b/other_distros/NixOS/fastermelee-5.9/default.nix
@@ -1,0 +1,104 @@
+{ stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib, libGLU_combined
+, gettext, libpthreadstubs, libXrandr, libXext, libX11, libSM, readline, openal
+, libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev, automake, autobuild
+, wxGTK31, soundtouch, miniupnpc, mbedtls, curl, lzo, sfml, gnumake
+, writeShellScriptBin, symlinkJoin, libpulseaudio ? null, sys ? null, user ? null }:
+
+# the optional sys and user parameters are paths to the respective directories for dolphin
+# if not given dolphin will just use the default fastermelee sys and user dirs
+# passing custom sys and user directories may be useful for installing project m
+
+let
+  # there are 2 wrapper scripts that will copy the necessary config files to $HOME/.config
+  # fastermelee is always called with the -u option so it reads the correct user dir
+  fastermelee = writeShellScriptBin "fastermelee" ''
+    config=$HOME/.config
+    if [ ! -z "$XDG_CONFIG_HOME" ]; then
+        config="$XDG_CONFIG_HOME"
+    fi
+    if [ ! -d $config ] ; then
+        mkdir -p $config
+        cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee
+        chmod -R +w $config/fastermelee
+    fi
+    ${fastermelee-dolphin}/bin/fastermelee -u $config/fastermelee
+  '';
+
+
+  fastermelee-nogui = writeShellScriptBin "fastermelee-nogui" ''
+    config=$HOME/.config
+    if [ ! -z "$XDG_CONFIG_HOME" ]; then
+        config="$XDG_CONFIG_HOME"
+    fi
+    if [ ! -d $config ] ; then
+        mkdir -p $config
+        cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee
+        chmod -R +w $config/fastermelee
+    fi
+    ${fastermelee-dolphin}/bin/fastermelee-nogui -u $config/fastermelee
+  '';
+
+  fasterMeleeConfig = builtins.fetchTarball
+    https://github.com/FasterMelee/FasterMelee-installer/raw/master/config/5.9-fmconfig.tar.gz;
+
+  sysDir = if sys== null then
+             "${fasterMeleeConfig}/Sys"
+           else
+             sys;
+
+
+  userDir = if user == null then
+             "${fasterMeleeConfig}/User"
+           else
+             user;
+
+
+  fastermelee-dolphin = stdenv.mkDerivation rec {
+    name = "FasterMelee-base";
+    version = "v5.9b";
+
+    src = fetchFromGitHub {
+      owner  = "FasterMelee";
+      repo   = "Ishiiruka";
+      rev ="4ecca10c2dc2f4cd33c5cfaed3cbb5a63142a709";
+      sha256 = "128906ggx0kcvp8nyfkl2nws8lgvb36215avv94axzc0pxx2kl5p";
+    };
+
+    postPatch = builtins.readFile ./postpatch;
+
+    cmakeFlags = ''
+      -DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include
+      -DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include
+      -DGTK2_INCLUDE_DIRS=${gtk2.dev}/lib/gtk-2.0
+      -DENABLE_LTO=True
+
+    '';
+
+    postInstall = ''
+      rm -r "$out/share/dolphin-emu/sys"
+      cp -r "${userDir}" "$out/share/dolphin-emu/user/"
+      cp -r "${sysDir}" "$out/share/dolphin-emu/sys/"
+      mv "$out/bin/dolphin-emu" "$out/bin/fastermelee"
+      mv "$out/bin/dolphin-emu-nogui" "$out/bin/fastermelee-nogui"
+    '';
+
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ pkgconfig cmake ];
+
+    buildInputs = [ bluez ffmpeg libao libGLU_combined gtk2 glib
+    gettext libpthreadstubs libXrandr libXext libX11 libSM readline
+    openal libevdev libXdmcp portaudio libusb libpulseaudio gnumake
+    wxGTK31 soundtouch miniupnpc mbedtls curl lzo sfml ];
+
+  };
+
+in
+  symlinkJoin {
+  name = "fastermelee";
+  paths = [
+    fastermelee
+    fastermelee-nogui
+    fastermelee-dolphin
+  ];
+}

--- a/other_distros/NixOS/fastermelee-5.9/default.nix
+++ b/other_distros/NixOS/fastermelee-5.9/default.nix
@@ -16,12 +16,12 @@ let
     if [ ! -z "$XDG_CONFIG_HOME" ]; then
         config="$XDG_CONFIG_HOME"
     fi
-    if [ ! -d $config ] ; then
+    if [ ! -d $config/fastermelee ] ; then
         mkdir -p $config
         cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee
         chmod -R +w $config/fastermelee
     fi
-    ${fastermelee-dolphin}/bin/fastermelee -u $config/fastermelee
+    ${fastermelee-dolphin}/bin/fastermelee -u $config/fastermelee $@
   '';
 
 
@@ -30,16 +30,20 @@ let
     if [ ! -z "$XDG_CONFIG_HOME" ]; then
         config="$XDG_CONFIG_HOME"
     fi
-    if [ ! -d $config ] ; then
+    if [ ! -d $config/fastermelee ] ; then
+       echo cp
         mkdir -p $config
         cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee
         chmod -R +w $config/fastermelee
     fi
-    ${fastermelee-dolphin}/bin/fastermelee-nogui -u $config/fastermelee
+    echo $config
+    ${fastermelee-dolphin}/bin/fastermelee-nogui $@
   '';
 
-  fasterMeleeConfig = builtins.fetchTarball
-    https://github.com/FasterMelee/FasterMelee-installer/raw/master/config/5.9-fmconfig.tar.gz;
+  fasterMeleeConfig = builtins.fetchTarball {
+    url = https://github.com/FasterMelee/FasterMelee-installer/raw/master/config/5.9-fmconfig.tar.gz;
+    sha256 = "1vs2fk5dpqlpb5sbrn6hc88pmdrlgif30vaf8g3nb7lrb4f6i8q6";
+  };
 
   sysDir = if sys== null then
              "${fasterMeleeConfig}/Sys"
@@ -55,7 +59,7 @@ let
 
   fastermelee-dolphin = stdenv.mkDerivation rec {
     name = "FasterMelee-base";
-    version = "v5.9b";
+    version = "5.9";
 
     src = fetchFromGitHub {
       owner  = "FasterMelee";

--- a/other_distros/NixOS/fastermelee-5.9/default.nix
+++ b/other_distros/NixOS/fastermelee-5.9/default.nix
@@ -31,7 +31,6 @@ let
         config="$XDG_CONFIG_HOME"
     fi
     if [ ! -d $config/fastermelee ] ; then
-       echo cp
         mkdir -p $config
         cp -r ${fastermelee-dolphin}/share/dolphin-emu/user $config/fastermelee
         chmod -R +w $config/fastermelee

--- a/other_distros/NixOS/fastermelee-5.9/postpatch
+++ b/other_distros/NixOS/fastermelee-5.9/postpatch
@@ -1,0 +1,31 @@
+#!/bin/sh
+echo "Patching xgetbv function..."
+sed -i "s|#include <cstring>|#include <cstring>\n#define _XSAVEINTRIN_H_INCLUDED|g" Source/Core/Common/x64CPUDetect.cpp # issue 1
+# sed -i "s|check_and_add_flag(CXX17 -std=c++17)|#check_and_add_flag(CXX17 -std=c++17)" # issue 2 not present
+# ---
+# --- Patch for https://github.com/FasterMelee/Ishiiruka/pull/4/commits/8d161226ab915be09c951957505da61c217b1b1b
+echo "Patching FileUtil.cpp..."
+sed -i "s|#include <fcntl.h>|#include <fcntl.h>\n#include <fstream>|g" Source/Core/Common/FileUtil.cpp # add in include
+sed -i '/\/\/ copies file srcFilename to destFilename, returns true on success/d' Source/Core/Common/FileUtil.cpp # update variable names
+sed -i "s|bool Copy(const std::string& srcFilename, const std::string& destFilename)|\/\/ copies file source_path to destination_path, returns true on success\nbool Copy(const std::string\& source_path, const std::string\& destination_path)|g" Source/Core/Common/FileUtil.cpp # update variable names
+sed -i 's|INFO_LOG(COMMON, "Copy: %s --> %s", srcFilename.c_str(), destFilename.c_str());|INFO_LOG(COMMON, "Copy: %s --> %s", source_path.c_str(), destination_path.c_str());|g' Source/Core/Common/FileUtil.cpp # update variable names
+sed -i "s|if (CopyFile(UTF8ToTStr(srcFilename).c_str(), UTF8ToTStr(destFilename).c_str(), FALSE))|if (CopyFile(UTF8ToTStr(source_path).c_str(), UTF8ToTStr(destination_path).c_str(), FALSE))|g" Source/Core/Common/FileUtil.cpp # update variable names
+sed -i 's|ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s", srcFilename.c_str(), destFilename.c_str(),|ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s", source_path.c_str(), destination_path.c_str(),|g' Source/Core/Common/FileUtil.cpp # update variable names
+sed -i "315,361d" Source/Core/Common/FileUtil.cpp # remove old copy method
+sed -i "314istd::ifstream source{source_path, std::ios::binary};\nstd::ofstream destination{destination_path, std::ios::binary};\ndestination << source.rdbuf();\nreturn source.good() && destination.good();" Source/Core/Common/FileUtil.cpp # add new copy method
+# ---
+
+# --- Patch WxUtils regarding https://github.com/FasterMelee/FasterMelee-installer/issues/58
+echo "Patching WxUtils.cpp..."
+sed -i "s|screen_geometry = wxDisplay(0).GetClientArea();|screen_geometry = wxDisplay((unsigned int) 0).GetClientArea();|g" Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
+sed -i 's|default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);|default_size.SetDefaults(wxDisplay((unsigned int) 0).GetClientArea().GetSize() / 2);|g' Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
+#   ---
+
+# --- Patch tarball to display correct hash to other netplay clients
+echo "Patching tarball..."
+sed -i "s|\${GIT_EXECUTABLE} rev-parse HEAD|echo 4a36badb6ff3ed533c26b3b201e6d3673a2353a8|g" CMakeLists.txt  # --set scm_rev_str everywhere to actual commit hash when downloaded
+sed -i "s|\${GIT_EXECUTABLE} describe --always --long --dirty|echo FM v$FMVERSION BETA|g" CMakeLists.txt # ensures compatibility w/ netplay
+sed -i "s|\${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD|echo HEAD|g" CMakeLists.txt
+# ---
+echo "patching cubeb"
+sed -i "s|install(DIRECTORY \${CMAKE_SOURCE_DIR}/include DESTINATION \${CMAKE_INSTALL_PREFIX})|install(DIRECTORY \${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION \${CMAKE_INSTALL_PREFIX})|g" Externals/cubeb/CMakeLists.txt

--- a/other_distros/NixOS/shell.nix
+++ b/other_distros/NixOS/shell.nix
@@ -1,16 +1,16 @@
-with import <nixpkgs> {};
-stdenv.mkDerivation {
+{ pkgs ? import <nixpkgs> {} }:
 
-  name = "fasterMelee";
+with pkgs;
+mkShell {
 
-  enableParallelBuilding = true;
-  gtk2 = pkgs.gtk2;
-  glib = pkgs.glib.out;
+  glib = glib.out;
+  gtk2 = gtk2;
 
-  nativeBuildInputs = [ pkgconfig cmake ];
-  buildInputs = [ pkgconfig bluez ffmpeg libao libGLU_combined gtk2 gtk3 glib
-  gettext xorg.libpthreadstubs xorg.libXrandr xorg.libXext xorg.libX11 xorg.libSM readline openal
-  libevdev xorg.libXdmcp portaudio libusb libpulseaudio libudev gnumake wget
-  wxGTK31 soundtouch miniupnpc mbedtls curl lzo sfml enet xdg_utils hidapi  ];
+  buildInputs = [ bluez ffmpeg libao libGLU_combined gtk2 glib gettext
+  xorg.libpthreadstubs xorg.libXrandr xorg.libXext xorg.libX11
+  xorg.libSM readline openal libevdev xorg.libXdmcp portaudio libusb
+  libpulseaudio gnumake wxGTK31 soundtouch miniupnpc mbedtls curl lzo
+  sfml pkgconfig cmake ];
+
 
 }

--- a/setup
+++ b/setup
@@ -195,6 +195,13 @@ sed -i "314istd::ifstream source{source_path, std::ios::binary};\nstd::ofstream 
 # ---
 
 
+# --- Patch WxUtils regarding https://github.com/FasterMelee/FasterMelee-installer/issues/58
+echo "Patching WxUtils.cpp..."
+sed -i "s|screen_geometry = wxDisplay(0).GetClientArea();|screen_geometry = wxDisplay((unsigned int) 0).GetClientArea();|g" Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
+sed -i 's|default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);|default_size.SetDefaults(wxDisplay((unsigned int) 0).GetClientArea().GetSize() / 2);|g' Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
+# ---
+
+
 if [ "$FMVERSION" = "5.8.7" ]; then
 	# --- Temporary patch for updated glibc		
 	echo "Patching xlocale.h requirement..."		
@@ -219,13 +226,8 @@ if [ "$FMVERSION" = "5.8.7" ]; then
 	echo "Using static soundtouch from Externals..."
 	sed -i 's|message("Using shared soundtouch")|add_subdirectory(Externals/soundtouch)\n\tinclude_directories(Externals)|g' CMakeLists.txt #uses external soundtouch lib
 	# ---
-else	
-	# --- Patch WxUtils regarding https://github.com/FasterMelee/FasterMelee-installer/issues/58
-	echo "Patching WxUtils.cpp..."
-        sed -i "s|screen_geometry = wxDisplay(0).GetClientArea();|screen_geometry = wxDisplay((unsigned int) 0).GetClientArea();|g" Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
-        sed -i 's|default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);|default_size.SetDefaults(wxDisplay((unsigned int) 0).GetClientArea().GetSize() / 2);|g' Source/Core/DolphinWX/WxUtils.cpp # avoid ambiguous overloaded function call
-	# ---
 
+else
 	# --- Patch tarball to display correct hash to other netplay clients
 	echo "Patching tarball..."
 	sed -i "s|\${GIT_EXECUTABLE} rev-parse HEAD|echo 4a36badb6ff3ed533c26b3b201e6d3673a2353a8|g" CMakeLists.txt  # --set scm_rev_str everywhere to actual commit hash when downloaded


### PR DESCRIPTION
Add a nix derivation for fastermelee 5.9 and 5.8.7. This simplifies the install process and allows you to install both automatically and globally.

Resolves: FasterMelee#12